### PR TITLE
Small improvements

### DIFF
--- a/src/main/java/org/wildfly/swarm/proc/CSVCollector.java
+++ b/src/main/java/org/wildfly/swarm/proc/CSVCollector.java
@@ -41,16 +41,16 @@ public class CSVCollector extends AbstractCollectorBase {
         }
 
         List<String> headerList = new ArrayList<>();
-        headerList.add("File");
-        headerList.add("Name");
+        headerList.add(FULL_FILE_PATH_COLUMN);
+        headerList.add(SHORT_FILE_NAME_COLUMN);
         for (Measure measure : Measure.values()) {
-            headerList.add(measure.getShortName() + SAMPLES);
-            headerList.add(measure.getShortName() + MIN);
-            headerList.add(measure.getShortName() + MAX);
-            headerList.add(measure.getShortName() + MEAN);
-            headerList.add(measure.getShortName() + STANDARD_DEVIATION);
-            headerList.add(measure.getShortName() + MEDIAN);
-            headerList.add(measure.getShortName() + PERCENTILE_75);
+            headerList.add(measure.columnSamples());
+            headerList.add(measure.columnMin());
+            headerList.add(measure.columnMax());
+            headerList.add(measure.columnMean());
+            headerList.add(measure.columnStandardDeviation());
+            headerList.add(measure.columnMedian());
+            headerList.add(measure.column75Percentile());
         }
         String[] header = headerList.toArray(new String[0]);
 
@@ -96,23 +96,9 @@ public class CSVCollector extends AbstractCollectorBase {
         csvOutput.close();
     }
 
-    public static final String SAMPLES = " Samples";
+    public static final String FULL_FILE_PATH_COLUMN = "File";
 
-    public static final String MIN = " Min";
-
-    public static final String MAX = " Max";
-
-    public static final String MEAN = " Mean";
-
-    public static final String STANDARD_DEVIATION = " Std Dev";
-
-    public static final String MEDIAN = " Median";
-
-    public static final String PERCENTILE_75 = " .75";
-
-    public static int STARTUP_PERCENTILE_IDX = 8;
-    public static int MEM_PERCENTILE_IDX = 15;
-    public static int FILE_NAME_IDX = 1;
+    public static final String SHORT_FILE_NAME_COLUMN = "Name";
 
     private final CSVPrinter csvOutput;
 }

--- a/src/main/java/org/wildfly/swarm/proc/CSVCollector.java
+++ b/src/main/java/org/wildfly/swarm/proc/CSVCollector.java
@@ -47,7 +47,10 @@ public class CSVCollector extends AbstractCollectorBase {
             headerList.add(measure.getShortName() + SAMPLES);
             headerList.add(measure.getShortName() + MIN);
             headerList.add(measure.getShortName() + MAX);
-            headerList.add(measure.getShortName() + PERCENTILE);
+            headerList.add(measure.getShortName() + MEAN);
+            headerList.add(measure.getShortName() + STANDARD_DEVIATION);
+            headerList.add(measure.getShortName() + MEDIAN);
+            headerList.add(measure.getShortName() + PERCENTILE_75);
         }
         String[] header = headerList.toArray(new String[0]);
 
@@ -74,6 +77,9 @@ public class CSVCollector extends AbstractCollectorBase {
             record.add(stats.getN());
             record.add(stats.getMin());
             record.add(stats.getMax());
+            record.add(stats.getMean());
+            record.add(stats.getStandardDeviation());
+            record.add(stats.getPercentile(50));
             record.add(stats.getPercentile(75));
         }
 
@@ -96,10 +102,16 @@ public class CSVCollector extends AbstractCollectorBase {
 
     public static final String MAX = " Max";
 
-    public static final String PERCENTILE = " .75";
+    public static final String MEAN = " Mean";
 
-    public static int STARTUP_PERCENTILE_IDX = 5;
-    public static int MEM_PERCENTILE_IDX = 9;
+    public static final String STANDARD_DEVIATION = " Std Dev";
+
+    public static final String MEDIAN = " Median";
+
+    public static final String PERCENTILE_75 = " .75";
+
+    public static int STARTUP_PERCENTILE_IDX = 8;
+    public static int MEM_PERCENTILE_IDX = 15;
     public static int FILE_NAME_IDX = 1;
 
     private final CSVPrinter csvOutput;

--- a/src/main/java/org/wildfly/swarm/proc/CsvOutputComparator.java
+++ b/src/main/java/org/wildfly/swarm/proc/CsvOutputComparator.java
@@ -27,21 +27,21 @@ public class CsvOutputComparator implements DeviationComparator {
     public void compare(List<CSVRecord> previous, List<CSVRecord> current) throws IOException {
         List<String> headerList = new ArrayList<>();
         headerList.add("Version");
-        headerList.add("Name");
+        headerList.add(CSVCollector.SHORT_FILE_NAME_COLUMN);
         for (Measure measure : Measure.values()) {
-            headerList.add(measure.getShortName() + CSVCollector.MIN);
-            headerList.add(measure.getShortName() + CSVCollector.MAX);
-            headerList.add(measure.getShortName() + CSVCollector.MEAN);
-            headerList.add(measure.getShortName() + CSVCollector.STANDARD_DEVIATION);
-            headerList.add(measure.getShortName() + CSVCollector.MEDIAN);
-            headerList.add(measure.getShortName() + CSVCollector.PERCENTILE_75);
+            headerList.add(measure.columnMin());
+            headerList.add(measure.columnMax());
+            headerList.add(measure.columnMean());
+            headerList.add(measure.columnStandardDeviation());
+            headerList.add(measure.columnMedian());
+            headerList.add(measure.column75Percentile());
         }
         String[] header = headerList.toArray(new String[0]);
 
         Appendable output = Files.newBufferedWriter(csvFile.toPath());
         try (CSVPrinter csv = CSVFormat.DEFAULT.withHeader(header).print(output)) {
             for (CSVRecord recordInPrevious : previous) {
-                String fileName = recordInPrevious.get(CSVCollector.FILE_NAME_IDX);
+                String fileName = recordInPrevious.get(CSVCollector.SHORT_FILE_NAME_COLUMN);
                 CSVRecord recordInCurrent = findMatching(fileName, current);
 
                 if (recordInCurrent != null) {
@@ -58,12 +58,12 @@ public class CsvOutputComparator implements DeviationComparator {
         values.add(version);
         values.add(fileName);
         for (Measure measure : Measure.values()) {
-            values.add(record.get(measure.getShortName() + CSVCollector.MIN));
-            values.add(record.get(measure.getShortName() + CSVCollector.MAX));
-            values.add(record.get(measure.getShortName() + CSVCollector.MEAN));
-            values.add(record.get(measure.getShortName() + CSVCollector.STANDARD_DEVIATION));
-            values.add(record.get(measure.getShortName() + CSVCollector.MEDIAN));
-            values.add(record.get(measure.getShortName() + CSVCollector.PERCENTILE_75));
+            values.add(record.get(measure.columnMin()));
+            values.add(record.get(measure.columnMax()));
+            values.add(record.get(measure.columnMean()));
+            values.add(record.get(measure.columnStandardDeviation()));
+            values.add(record.get(measure.columnMedian()));
+            values.add(record.get(measure.column75Percentile()));
         }
 
         csv.printRecord(values);

--- a/src/main/java/org/wildfly/swarm/proc/CsvOutputComparator.java
+++ b/src/main/java/org/wildfly/swarm/proc/CsvOutputComparator.java
@@ -1,0 +1,72 @@
+package org.wildfly.swarm.proc;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.CSVRecord;
+
+public class CsvOutputComparator implements DeviationComparator {
+    private final File csvFile;
+
+    private final String previousName;
+
+    private final String currentName;
+
+    public CsvOutputComparator(File csvFile, String previousName, String currentName) {
+        this.csvFile = csvFile;
+        this.previousName = previousName;
+        this.currentName = currentName;
+    }
+
+    @Override
+    public void compare(List<CSVRecord> previous, List<CSVRecord> current) throws IOException {
+        List<String> headerList = new ArrayList<>();
+        headerList.add("Version");
+        headerList.add("Name");
+        for (Measure measure : Measure.values()) {
+            headerList.add(measure.getShortName() + CSVCollector.MIN);
+            headerList.add(measure.getShortName() + CSVCollector.MAX);
+            headerList.add(measure.getShortName() + CSVCollector.MEAN);
+            headerList.add(measure.getShortName() + CSVCollector.STANDARD_DEVIATION);
+            headerList.add(measure.getShortName() + CSVCollector.MEDIAN);
+            headerList.add(measure.getShortName() + CSVCollector.PERCENTILE_75);
+        }
+        String[] header = headerList.toArray(new String[0]);
+
+        Appendable output = Files.newBufferedWriter(csvFile.toPath());
+        try (CSVPrinter csv = CSVFormat.DEFAULT.withHeader(header).print(output)) {
+            for (CSVRecord recordInPrevious : previous) {
+                String fileName = recordInPrevious.get(CSVCollector.FILE_NAME_IDX);
+                CSVRecord recordInCurrent = findMatching(fileName, current);
+
+                if (recordInCurrent != null) {
+                    printRecord(csv, previousName, fileName, recordInPrevious);
+                    printRecord(csv, currentName, fileName, recordInCurrent);
+                }
+            }
+        }
+    }
+
+    private void printRecord(CSVPrinter csv, String version, String fileName, CSVRecord record) throws IOException {
+        List<Object> values = new ArrayList<>();
+
+        values.add(version);
+        values.add(fileName);
+        for (Measure measure : Measure.values()) {
+            values.add(record.get(measure.getShortName() + CSVCollector.MIN));
+            values.add(record.get(measure.getShortName() + CSVCollector.MAX));
+            values.add(record.get(measure.getShortName() + CSVCollector.MEAN));
+            values.add(record.get(measure.getShortName() + CSVCollector.STANDARD_DEVIATION));
+            values.add(record.get(measure.getShortName() + CSVCollector.MEDIAN));
+            values.add(record.get(measure.getShortName() + CSVCollector.PERCENTILE_75));
+        }
+
+        csv.printRecord(values);
+    }
+
+}

--- a/src/main/java/org/wildfly/swarm/proc/DeviationComparator.java
+++ b/src/main/java/org/wildfly/swarm/proc/DeviationComparator.java
@@ -28,7 +28,7 @@ import org.apache.commons.csv.CSVRecord;
  */
 public interface DeviationComparator {
 
-    void compare(List<CSVRecord> previous, List<CSVRecord> current) throws ThresholdExceeded;
+    void compare(List<CSVRecord> previous, List<CSVRecord> current) throws Exception;
 
     default CSVRecord findMatching(String fileName, List<CSVRecord> records) {
         return records.stream()

--- a/src/main/java/org/wildfly/swarm/proc/DeviationComparator.java
+++ b/src/main/java/org/wildfly/swarm/proc/DeviationComparator.java
@@ -32,7 +32,7 @@ public interface DeviationComparator {
 
     default CSVRecord findMatching(String fileName, List<CSVRecord> records) {
         return records.stream()
-                .filter(r -> fileName.equals(r.get(CSVCollector.FILE_NAME_IDX)))
+                .filter(r -> fileName.equals(r.get(CSVCollector.SHORT_FILE_NAME_COLUMN)))
                 .findFirst()
                 .orElse(null);
     }

--- a/src/main/java/org/wildfly/swarm/proc/FailFastComparator.java
+++ b/src/main/java/org/wildfly/swarm/proc/FailFastComparator.java
@@ -48,14 +48,9 @@ public class FailFastComparator implements DeviationComparator {
 
     @Override
     public void compare(List<CSVRecord> previous, List<CSVRecord> current) throws ThresholdExceeded {
-        boolean skipedFirst = false;
         List<ComparisonResult> comparisonResults = new ArrayList<>();
         int maxChars = 0;
         for (CSVRecord prevRecord : previous) {
-            if(!skipedFirst) { // CSV headers
-                skipedFirst = true;
-                continue;
-            }
             String fileName = prevRecord.get(CSVCollector.FILE_NAME_IDX);
             if(fileName.length()>maxChars) maxChars = fileName.length();
             CSVRecord matching = findMatching(fileName, current);

--- a/src/main/java/org/wildfly/swarm/proc/FailFastComparator.java
+++ b/src/main/java/org/wildfly/swarm/proc/FailFastComparator.java
@@ -21,9 +21,9 @@ package org.wildfly.swarm.proc;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.csv.CSVRecord;
@@ -37,13 +37,13 @@ public class FailFastComparator implements DeviationComparator {
 
     private final double threshold;
 
-    private final Map<Measure, Integer> criteria = new HashMap<>();
+    private final Set<Measure> criteria = new HashSet<>();
 
     public FailFastComparator(double threshold) {
         this.threshold = threshold;
 
-        criteria.put(Measure.RSS_AFTER_INVOCATION, CSVCollector.MEM_PERCENTILE_IDX);
-        criteria.put(Measure.STARTUP_TIME, CSVCollector.STARTUP_PERCENTILE_IDX);
+        criteria.add(Measure.RSS_AFTER_INVOCATION);
+        criteria.add(Measure.STARTUP_TIME);
     }
 
     @Override
@@ -51,15 +51,14 @@ public class FailFastComparator implements DeviationComparator {
         List<ComparisonResult> comparisonResults = new ArrayList<>();
         int maxChars = 0;
         for (CSVRecord prevRecord : previous) {
-            String fileName = prevRecord.get(CSVCollector.FILE_NAME_IDX);
+            String fileName = prevRecord.get(CSVCollector.SHORT_FILE_NAME_COLUMN);
             if(fileName.length()>maxChars) maxChars = fileName.length();
             CSVRecord matching = findMatching(fileName, current);
             if(matching!=null) {
 
-                for (Measure measure : criteria.keySet()) {
-                    int idx = criteria.get(measure);
-                    double prevVal = Double.valueOf(prevRecord.get(idx));
-                    double currVal = Double.valueOf(matching.get(idx));
+                for (Measure measure : criteria) {
+                    double prevVal = Double.valueOf(prevRecord.get(measure.column75Percentile()));
+                    double currVal = Double.valueOf(matching.get(measure.column75Percentile()));
 
                     if(currVal>prevVal) {
 

--- a/src/main/java/org/wildfly/swarm/proc/Jcmd.java
+++ b/src/main/java/org/wildfly/swarm/proc/Jcmd.java
@@ -1,0 +1,40 @@
+package org.wildfly.swarm.proc;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Triggers diagnostic commands on a JVM using {@code jcmd}.
+ */
+final class Jcmd {
+    private static final String GC = "GC.run";
+
+    public static void gc(long pid) throws Exception {
+        perform(pid, GC);
+    }
+
+    private static void perform(long pid, String command) throws Exception {
+        Process process = null;
+        BufferedReader reader = null;
+
+        try {
+            ProcessBuilder builder = new ProcessBuilder("jcmd", "" + pid, command);
+            builder.environment().put("LC_ALL", "c");
+            process = builder.start();
+            reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+            while (reader.readLine() != null) {
+                // read all the output
+            }
+        } finally {
+            if (reader != null) {
+                reader.close();
+            }
+            if (process != null && process.isAlive()) {
+                process.destroyForcibly().waitFor(5, TimeUnit.SECONDS);
+            }
+        }
+
+    }
+}

--- a/src/main/java/org/wildfly/swarm/proc/Jstat.java
+++ b/src/main/java/org/wildfly/swarm/proc/Jstat.java
@@ -10,11 +10,12 @@ import java.util.concurrent.TimeUnit;
 final class Jstat {
     private static final String[] RELEVANT_JSTAT_OUTPUT_COLUMNS = {
             "S0U", // used survivor space 0
-            "S1U", // used survivor space 1
+            "S1U", // used survivor space 1; note that one of S0U and S1U is always 0
             "EU",  // used eden space
             "OU",  // used old space
-            "MU",  // used metaspace
-            "CCSU" // used compressed class space
+            // common tools (jconsole, jvisualvm, jmc) report these as non-heap memory
+            //"MU",  // used metaspace
+            //"CCSU" // used compressed class space; note that it's actually part of metaspace, so computing MU + CCSU is wrong
     };
 
     /**

--- a/src/main/java/org/wildfly/swarm/proc/Measure.java
+++ b/src/main/java/org/wildfly/swarm/proc/Measure.java
@@ -40,5 +40,33 @@ public enum Measure {
         return shortName;
     }
 
+    public String columnSamples() {
+        return shortName + " Samples";
+    }
+
+    public String columnMin() {
+        return shortName + " Min";
+    }
+
+    public String columnMax() {
+        return shortName + " Max";
+    }
+
+    public String columnMean() {
+        return shortName + " Mean";
+    }
+
+    public String columnStandardDeviation() {
+        return shortName + " Std Dev";
+    }
+
+    public String columnMedian() {
+        return shortName + " Median";
+    }
+
+    public String column75Percentile() {
+        return shortName + " .75";
+    }
+
     private final String shortName;
 }

--- a/src/main/java/org/wildfly/swarm/proc/Monitor.java
+++ b/src/main/java/org/wildfly/swarm/proc/Monitor.java
@@ -222,7 +222,7 @@ public class Monitor {
 
     private CSVParser loadCSV(File file) throws Exception {
         Reader input = Files.newBufferedReader(file.toPath());
-        return CSVFormat.DEFAULT.parse(input);
+        return CSVFormat.DEFAULT.withHeader().parse(input);
     }
 
     private static boolean isSameFile(Path path1, Path path2) {

--- a/src/main/java/org/wildfly/swarm/proc/Monitor.java
+++ b/src/main/java/org/wildfly/swarm/proc/Monitor.java
@@ -69,6 +69,7 @@ public class Monitor {
         archiveDir = cmd.hasOption("a") ? Optional.of(new File(cmd.getOptionValue("a"))) : Optional.empty();
 
         outputFile = cmd.hasOption("o") ? Optional.of(new File(cmd.getOptionValue("o"))) : Optional.empty();
+        comparisonOutputFile = cmd.hasOption("c") ? Optional.of(new File(cmd.getOptionValue("c"))) : Optional.empty();
 
         System.out.println("Base dir: "+ baseDir.getAbsolutePath());
 
@@ -134,6 +135,14 @@ public class Monitor {
                 .required(true)
                 .hasArg()
                 .desc("where to store testing artifacts")
+                .build()
+        );
+
+        options.addOption(Option.builder("c")
+                .longOpt("comparison-csv")
+                .required(false)
+                .hasArg()
+                .desc("the .csv file to store the comparison")
                 .build()
         );
 
@@ -216,6 +225,12 @@ public class Monitor {
 
         List<CSVRecord> current = loadCSV(testResult).getRecords();
         List<CSVRecord> previous = loadCSV(archivedResult.getFile()).getRecords();
+
+        if (comparisonOutputFile.isPresent()) {
+            String previousName = archivedResult.getVersion().toString();
+            String currentName = testResult.getName().replaceFirst(".csv$", "");
+            new CsvOutputComparator(comparisonOutputFile.get(), previousName, currentName).compare(previous, current);
+        }
 
         new FailFastComparator(10.00).compare(previous, current);
     }
@@ -383,6 +398,8 @@ public class Monitor {
     private final Optional<File> archiveDir;
 
     private final Optional<File> outputFile;
+
+    private final Optional<File> comparisonOutputFile;
 
     private final Collector collector;
 


### PR DESCRIPTION
This is mostly about new features:

- ability to create a comparison .csv that is well-suited (hopefully) for loading into a spreadsheet and creating charts
- CSVs now contain also mean, std dev and median of the measured values
- Java heap space is measured correctly (no longer includes the size of metaspace and ccspace)
- also memory measurements are only done after a short warmup (100 requests) and a Java GC

There have also been some implementation cleanups, mostly about using column names instead of numeric indices (which are brittle).

For review, I think reviewing each commit separately would work nicely, but reviewing the total changeset at once should be workable as well.