### PR TITLE
Fix org.wildfly.swarm.proc.ThresholdExceeded exception that is launched when there are NO tests with exceeded threshold

### DIFF
--- a/src/main/java/org/wildfly/swarm/proc/FailFastComparator.java
+++ b/src/main/java/org/wildfly/swarm/proc/FailFastComparator.java
@@ -92,7 +92,7 @@ public class FailFastComparator implements DeviationComparator {
         comparisonResults.forEach(r -> System.out.println(StringUtils.rightPad(r.getFile(), pad)+": "+r.getMessage()));
 
         // decide if ThresholdExceeded
-        List<ComparisonResult> failedTests = comparisonResults.stream().filter(r -> !r.isFailure()).collect(Collectors.toList());
+        List<ComparisonResult> failedTests = comparisonResults.stream().filter(r -> r.isFailure()).collect(Collectors.toList());
         if(failedTests.size()>0) {
             System.err.println("There have been test errors. See previous logs for details ...");
             throw new ThresholdExceeded(failedTests.size() + " test(s) did exceed the "+this.threshold+"% tolerance.");


### PR DESCRIPTION
Hi @heiko-braun. I was testing this project (it's great BTW!) and came across this behavior seems isn't right.

ThresholdExceededException was launched even when there weren't any test beyond the 10% threshold. After fix seems it's only launched when that condition is met.

Hope it makes sense.

Thanks!